### PR TITLE
[refactor/ABOUT-59] Room Database 테이블간의 관계 설정 + CASCADE 설정

### DIFF
--- a/app/src/main/java/com/w36495/about/domain/entity/Comment.kt
+++ b/app/src/main/java/com/w36495/about/domain/entity/Comment.kt
@@ -1,9 +1,22 @@
 package com.w36495.about.domain.entity
 
 import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.ForeignKey.CASCADE
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "comments")
+@Entity(
+    tableName = "comments",
+    foreignKeys = [
+        ForeignKey(
+            entity = Think::class,
+            parentColumns = ["id"],
+            childColumns = ["thinkId"],
+            onUpdate = CASCADE,
+            onDelete = CASCADE
+        )
+    ]
+)
 data class Comment(
     @PrimaryKey
     val id: Long = System.currentTimeMillis(),

--- a/app/src/main/java/com/w36495/about/domain/entity/Think.kt
+++ b/app/src/main/java/com/w36495/about/domain/entity/Think.kt
@@ -5,10 +5,10 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "thinks")
 data class Think(
-    var topicId: Long,
-    var text: String,
+    @PrimaryKey
+    val id: Long = System.currentTimeMillis(),
+    val topicId: Long,
+    val think: String,
     val registDate: String,
-    var updateDate: String
-) {
-    @PrimaryKey(autoGenerate = true) var id: Long = 0
-}
+    val updateDate: String
+)

--- a/app/src/main/java/com/w36495/about/domain/entity/Think.kt
+++ b/app/src/main/java/com/w36495/about/domain/entity/Think.kt
@@ -1,9 +1,22 @@
 package com.w36495.about.domain.entity
 
 import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.ForeignKey.CASCADE
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "thinks")
+@Entity(
+    tableName = "thinks",
+    foreignKeys = [
+        ForeignKey(
+            entity = Topic::class,
+            parentColumns = ["id"],
+            childColumns = ["topicId"],
+            onDelete = CASCADE,
+            onUpdate = CASCADE
+        )
+    ]
+)
 data class Think(
     @PrimaryKey
     val id: Long = System.currentTimeMillis(),

--- a/app/src/main/java/com/w36495/about/domain/entity/Topic.kt
+++ b/app/src/main/java/com/w36495/about/domain/entity/Topic.kt
@@ -5,11 +5,9 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "topics")
 data class Topic(
+    @PrimaryKey
+    val id: Long = System.currentTimeMillis(),
     val topic: String,
-    val color: String,
-    val registDate: String
-) {
-    @PrimaryKey(autoGenerate = true)
-    var id: Long = 0
-    var count: Int = 0
-}
+    val registDate: String,
+    val updateDate: String
+)


### PR DESCRIPTION
- 변경 전 테이블
  - 각 테이블간의 외래 키를 지정하지 않음

- 변경 후
  - 불필요한 컬럼 삭제
    - Topic 테이블의 color / count 
  - 새로운 컬럼 추가
    - Topic 테이블의 updateDate
  - 테이블 간의 관계 설정
    - Think 테이블의 topicId -> Topic 의 기본 키(id) 참조
    - Comment 테이블의 thinkId -> Think 의 기본 키(id) 참조
    - 각 외래 키에 CASCADE (ON DELETE/ON UPDATE) 설정