### PR TITLE
[bug/ABOUT-65] 코멘트 아이템 스와이프하는 경우, 이전에 선택한 코멘트의 상태 변경이 안됨

### DIFF
--- a/app/src/main/java/com/w36495/about/ui/adapter/CommentListAdapter.kt
+++ b/app/src/main/java/com/w36495/about/ui/adapter/CommentListAdapter.kt
@@ -24,7 +24,7 @@ class CommentListAdapter : RecyclerView.Adapter<CommentListViewHolder>() {
         }
 
         holder.onDeleteClick = {
-            commentItemClickListener.onItemClicked(commentList[it.adapterPosition].id)
+            commentItemClickListener.onClickItem(commentList[it.adapterPosition].id)
         }
     }
 

--- a/app/src/main/java/com/w36495/about/ui/fragment/ThinkFragment.kt
+++ b/app/src/main/java/com/w36495/about/ui/fragment/ThinkFragment.kt
@@ -101,6 +101,10 @@ class ThinkFragment(
             adapter = commentListAdapter
             layoutManager =
                 LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+            setOnTouchListener { _, _ ->
+                commentItemTouchHelper.removePreviousSwipe(this)
+                false
+            }
         }
 
         commentListAdapter.setOnCommentItemClickListener(this)
@@ -170,6 +174,7 @@ class ThinkFragment(
     }
 
     override fun onDeleteItem(commentId: Long) {
+        commentItemTouchHelper.removeSwipeAfterDelete(binding.thinkRecyclerview)
         presenter.deleteComment(commentId)
     }
 

--- a/app/src/main/java/com/w36495/about/ui/fragment/ThinkFragment.kt
+++ b/app/src/main/java/com/w36495/about/ui/fragment/ThinkFragment.kt
@@ -163,7 +163,7 @@ class ThinkFragment(
         Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
     }
 
-    override fun onItemClicked(commentId: Long) {
+    override fun onClickItem(commentId: Long) {
         val commentBottomDialog = CommentBottomSheetDialogFragment(commentId)
         commentBottomDialog.setOnCommentItemDeleteListener(this)
         commentBottomDialog.show(parentFragmentManager, "COMMENT_BOTTOM_DIALOG")

--- a/app/src/main/java/com/w36495/about/ui/listener/CommentItemClickListener.kt
+++ b/app/src/main/java/com/w36495/about/ui/listener/CommentItemClickListener.kt
@@ -1,5 +1,5 @@
 package com.w36495.about.ui.listener
 
 interface CommentItemClickListener {
-    fun onItemClicked(commentId: Long)
+    fun onClickItem(commentId: Long)
 }

--- a/app/src/main/java/com/w36495/about/ui/listener/CommentItemTouchHelper.kt
+++ b/app/src/main/java/com/w36495/about/ui/listener/CommentItemTouchHelper.kt
@@ -16,6 +16,9 @@ class CommentItemTouchHelper : ItemTouchHelper.Callback() {
     private var initXWhenInActive = 0f
     private var firstInActive = false
 
+    private var currentPosition: Int? = null
+    private var previousPosition: Int? = null
+
     override fun getMovementFlags(
         recyclerView: RecyclerView,
         viewHolder: ViewHolder
@@ -79,6 +82,8 @@ class CommentItemTouchHelper : ItemTouchHelper.Callback() {
     override fun clearView(recyclerView: RecyclerView, viewHolder: ViewHolder) {
         super.clearView(recyclerView, viewHolder)
 
+        previousPosition = viewHolder.adapterPosition
+
         val currentScrollX = viewHolder.itemView.scrollX * (-1)
 
         if (currentScrollX > limitScrollX) {
@@ -88,11 +93,39 @@ class CommentItemTouchHelper : ItemTouchHelper.Callback() {
         }
     }
 
+    override fun onSelectedChanged(viewHolder: ViewHolder?, actionState: Int) {
+        super.onSelectedChanged(viewHolder, actionState)
+
+        viewHolder?.let {
+            currentPosition = it.adapterPosition
+        }
+    }
+
     override fun getSwipeThreshold(viewHolder: ViewHolder): Float {
         return Integer.MAX_VALUE.toFloat()
     }
 
     override fun getSwipeEscapeVelocity(defaultValue: Float): Float {
         return Integer.MAX_VALUE.toFloat()
+    }
+
+    fun removePreviousSwipe(recyclerView: RecyclerView) {
+        if (previousPosition == currentPosition) {
+            return
+        } else {
+            previousPosition?.let {
+                val viewHolder = recyclerView.findViewHolderForAdapterPosition(it) ?: return
+                viewHolder.itemView.scrollTo(0, 0)
+                previousPosition = null
+            }
+        }
+    }
+
+    fun removeSwipeAfterDelete(recyclerView: RecyclerView) {
+        currentPosition?.let {
+            val viewHolder = recyclerView.findViewHolderForAdapterPosition(it) ?: return
+            viewHolder.itemView.scrollTo(0, 0)
+            currentPosition = null
+        }
     }
 }


### PR DESCRIPTION
### Todo
- [x] 코멘트 스와이프 시, 이전 코멘트는 원상태로 복귀시키기

### 변경 전
- 이전 코멘트의 상태가 유지됨

![버그_코멘트삭제](https://github.com/w36495/about/assets/52291662/da69227d-18db-4e8d-80ed-86c4f2a5425a)

### 변경 후
- 다른 아이템 스와이프 혹은 삭제 시, 이전 코멘트의 상태 초기화

![코멘트삭제_수정후](https://github.com/w36495/about/assets/52291662/6fe6e428-24cd-4922-ae64-e3c190ada23a)
