### PR TITLE
[bug/ABOUT-56] 주제 목록에 해당하는 총 생각 개수가 일치하지 않음

### DIFF
--- a/app/src/main/java/com/w36495/about/data/local/CommentDao.kt
+++ b/app/src/main/java/com/w36495/about/data/local/CommentDao.kt
@@ -16,12 +16,12 @@ interface CommentDao {
     fun getCountCommentList(thinkId: Long): Flow<Int>
 
     @Insert
-    fun insertComment(comment: Comment)
+    suspend fun insertComment(comment: Comment)
 
     @Query("DELETE FROM comments WHERE id = :commentId")
-    fun deleteCommentById(commentId: Long)
+    suspend fun deleteCommentById(commentId: Long)
 
     @Query("DELETE FROM comments WHERE thinkId = :thinkId")
-    fun deleteAllComment(thinkId: Long)
+    suspend fun deleteAllComment(thinkId: Long)
 
 }

--- a/app/src/main/java/com/w36495/about/data/local/ThinkDao.kt
+++ b/app/src/main/java/com/w36495/about/data/local/ThinkDao.kt
@@ -7,29 +7,29 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ThinkDao {
     @Query("SELECT * FROM thinks WHERE topicId = :topicId")
-    fun getThinkListByTopicId(topicId: Long): List<Think>
+    fun getThinkListByTopicId(topicId: Long): Flow<List<Think>>
 
     @Query("SELECT * FROM thinks WHERE id = :thinkId")
     fun getThinkById(thinkId: Long): Flow<Think>
 
     @Query("SELECT count(*) FROM thinks WHERE topicId = :topicId")
-    fun getThinkListSizeByTopicId(topicId: Long): Int
+    fun getCountOfThinkListByTopicId(topicId: Long): Flow<String>
 
     @Update
-    fun updateThink(think: Think)
+    suspend fun updateThink(think: Think)
 
     @Insert
-    fun insertThink(think: Think)
+    suspend fun insertThink(think: Think)
 
     @Query("DELETE FROM thinks WHERE topicId = :topicId")
-    fun deleteThinkByTopicId(topicId: Long)
+    suspend fun deleteThinkByTopicId(topicId: Long)
 
     @Query("DELETE FROM thinks WHERE id = :thinkId")
-    fun deleteThinkById(thinkId: Long)
+    suspend fun deleteThinkById(thinkId: Long)
 
     @Query("DELETE FROM thinks")
-    fun deleteAllThinks()
+    suspend fun deleteAllThinks()
 
     @Query("SELECT count(*) FROM thinks")
-    fun getThinkListCount(): Int
+    suspend fun getThinkListCount(): Int
 }

--- a/app/src/main/java/com/w36495/about/data/local/TopicDao.kt
+++ b/app/src/main/java/com/w36495/about/data/local/TopicDao.kt
@@ -3,16 +3,23 @@ package com.w36495.about.data.local
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import com.w36495.about.domain.dto.TopicListDTO
 import com.w36495.about.domain.entity.Topic
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface TopicDao{
-    @Query("SELECT * FROM topics")
-    fun getTopicList(): Flow<List<Topic>>
 
     @Query("SELECT * FROM topics WHERE id = :topicId")
-    suspend fun getTopicById(topicId: Long): Topic
+    fun getTopicById(topicId: Long): Flow<Topic>
+
+    @Query("""
+        SELECT topics.id, topics.topic, COUNT(topicId) AS countOfThink, topics.registDate, topics.updateDate
+        FROM topics
+        LEFT JOIN thinks ON topics.id = thinks.topicId
+        GROUP BY topics.id
+    """)
+    fun getTopicList(): Flow<List<TopicListDTO>>
 
     @Insert
     suspend fun insertTopic(topic: Topic)

--- a/app/src/main/java/com/w36495/about/data/repository/TopicRepository.kt
+++ b/app/src/main/java/com/w36495/about/data/repository/TopicRepository.kt
@@ -1,13 +1,14 @@
 package com.w36495.about.data.repository
 
+import com.w36495.about.domain.dto.TopicListDTO
 import com.w36495.about.domain.entity.Topic
 import kotlinx.coroutines.flow.Flow
 
 interface TopicRepository {
 
-    suspend fun getTopicById(topicId: Long): Topic
+    suspend fun getTopicById(topicId: Long): Flow<Topic>
 
-    suspend fun getTopicList(): Flow<List<Topic>>
+    suspend fun getTopicList(): Flow<List<TopicListDTO>>
 
     suspend fun insertTopic(topic: Topic): String
 

--- a/app/src/main/java/com/w36495/about/data/repository/TopicRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/about/data/repository/TopicRepositoryImpl.kt
@@ -1,15 +1,16 @@
 package com.w36495.about.data.repository
 
 import com.w36495.about.data.local.TopicDao
+import com.w36495.about.domain.dto.TopicListDTO
 import com.w36495.about.domain.entity.Topic
 import kotlinx.coroutines.flow.Flow
 
 class TopicRepositoryImpl(private val topicDao: TopicDao) : TopicRepository {
-    override suspend fun getTopicById(topicId: Long): Topic {
+    override suspend fun getTopicById(topicId: Long): Flow<Topic> {
         return topicDao.getTopicById(topicId)
     }
 
-    override suspend fun getTopicList(): Flow<List<Topic>> {
+    override suspend fun getTopicList(): Flow<List<TopicListDTO>> {
         return topicDao.getTopicList()
     }
 

--- a/app/src/main/java/com/w36495/about/domain/dto/TopicListDTO.kt
+++ b/app/src/main/java/com/w36495/about/domain/dto/TopicListDTO.kt
@@ -1,9 +1,12 @@
 package com.w36495.about.domain.dto
 
+import androidx.room.ColumnInfo
+
 data class TopicListDTO(
     val id: Long,
     val topic: String,
-    val countOfThink: Int = 0,
+    @ColumnInfo(name = "countOfThink")
+    val countOfThink: Int,
     val registDate: String,
     val updateDate: String
 )

--- a/app/src/main/java/com/w36495/about/domain/entity/Topic.kt
+++ b/app/src/main/java/com/w36495/about/domain/entity/Topic.kt
@@ -2,7 +2,6 @@ package com.w36495.about.domain.entity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.w36495.about.domain.dto.TopicListDTO
 
 @Entity(tableName = "topics")
 data class Topic(
@@ -11,14 +10,4 @@ data class Topic(
     val topic: String,
     val registDate: String,
     val updateDate: String
-) {
-    fun toTopicListDTO(count: Int): TopicListDTO {
-        return TopicListDTO(
-            id = id,
-            topic = topic,
-            countOfThink = count,
-            registDate = registDate,
-            updateDate = updateDate
-        )
-    }
-}
+)

--- a/app/src/main/java/com/w36495/about/ui/presenter/TopicPresenter.kt
+++ b/app/src/main/java/com/w36495/about/ui/presenter/TopicPresenter.kt
@@ -41,13 +41,8 @@ class TopicPresenter(
                 .catch { exception ->
                     _topicListUiState.value = TopicListUiState.Failed(TAG_TOPIC_LIST_PRESENTER, exception.localizedMessage)
                 }
-                .collectLatest { topicList ->
-                    topicList.forEach { topic ->
-                        thinkRepository.getCountOfThinkListByTopicId(topic.id)
-                            .collect { count ->
-                                _topicListUiState.value = TopicListUiState.Success(topicList.map { it.toTopicListDTO(count.toInt()) })
-                            }
-                    }
+                .collectLatest {
+                    _topicListUiState.value = TopicListUiState.Success(it)
                 }
         }
     }


### PR DESCRIPTION
### Problem
- 취미 주제에 대한 생각 개수가 >독서 주제< 에도 영향을 미침
### Todo
- [x] 생각의 총 개수가 다른 주제에 영향을 미치지 않도록 쿼리문 수정

### 시행착오

---
### 변경 전
![버그_생각개수](https://github.com/w36495/about/assets/52291662/b21a2347-09d3-46d4-9d3c-aa41e5645d3b)

- 취미 목록의 개수가 증가하면, 독서 목록의 총 개수도 증가

### 변경 후
![버그_생각개수_수정후](https://github.com/w36495/about/assets/52291662/493de4b1-308d-4661-a141-695f848c1b61)

- 각 주제에 대해 서로 영향을 미치지 않도록 쿼리문 수정
