### PR TITLE
[bug/ABOUT-71] 생각 화면에서 바텀 네비게이션의 주제를 클릭했을 때, 주제 목록으로 돌아오지 않음

### DIFF
--- a/app/src/main/java/com/w36495/about/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/w36495/about/ui/activity/MainActivity.kt
@@ -35,7 +35,23 @@ class MainActivity : AppCompatActivity() {
         val navHost = supportFragmentManager.findFragmentById(R.id.main_fragment_container) as NavHostFragment
         val navController = navHost.navController
 
-        binding.mainBottomNavigation.setupWithNavController(navController)
+        binding.mainBottomNavigation.apply {
+            setupWithNavController(navController)
+
+            setOnItemSelectedListener {
+                when(it.itemId) {
+                    R.id.nav_topicList_fragment -> {
+                        navController.navigate(R.id.nav_topicList_fragment)
+                        true
+                    }
+                    R.id.nav_setting_fragment -> {
+                        navController.navigate(R.id.nav_setting_fragment)
+                        true
+                    }
+                    else -> false
+                }
+            }
+        }
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
### Todo
- [x] 바텀 네비게이션의 주제 버튼 클릭 시, 주제 목록 화면으로 돌아옴

---
|변경 전|변경 후|
|--|--|
|![ezgif com-video-to-gif (3)](https://github.com/w36495/about/assets/52291662/96f6a5c9-5f3b-47d7-8f7f-79d2e9c68d3c)|![바텀네비게이션클릭시,주제목록으로 돌아옴](https://github.com/w36495/about/assets/52291662/393bb725-ee47-42c9-9f52-dd48383bf4e9)|
